### PR TITLE
feat: update requirements.txt to provide SARIF formatter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bandit==1.7.5
+bandit_sarif_formatter==1.1.1


### PR DESCRIPTION
This PR adds the [bandit_sarif_formatter](https://github.com/microsoft/bandit-sarif-formatter) from Microsoft, which allows to set `--format sarif` to output results in SARIF format. This is very useful when working with some tools or integrating with the Code Scanning of GitHub.

Example usage after merge:
```yaml
- name: Run Bandit for Python function
  continue-on-error: true
  uses: jpetrucciani/bandit-check@master
  with:
    bandit_flags: '--format sarif --output bandit.sarif'
```